### PR TITLE
Add timeout to lookupTransform

### DIFF
--- a/src/robot_pose_publisher.cpp
+++ b/src/robot_pose_publisher.cpp
@@ -12,12 +12,12 @@
 #include <chrono>
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
-#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "tf2_ros/transform_listener.h"
+#include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 
 using namespace std::chrono_literals;
 
@@ -27,73 +27,69 @@ using namespace std::chrono_literals;
 class RobotPosePublisher : public rclcpp::Node
 {
 public:
-	RobotPosePublisher() : Node("robot_pose_publisher")
-	{
-		tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-		tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+  RobotPosePublisher() : Node("robot_pose_publisher")
+  {
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
-		this->declare_parameter<std::string>("map_frame","map");
-		this->declare_parameter<std::string>("base_frame","base_link");
-		this->declare_parameter<bool>("is_stamped",false);
+    this->declare_parameter<std::string>("map_frame", "map");
+    this->declare_parameter<std::string>("base_frame", "base_link");
+    this->declare_parameter<bool>("is_stamped", false);
 
-		this->get_parameter("map_frame", map_frame);
-		this->get_parameter("base_frame", base_frame);
-		this->get_parameter("is_stamped", is_stamped);
+    this->get_parameter("map_frame", map_frame_);
+    this->get_parameter("base_frame", base_frame_);
+    this->get_parameter("is_stamped", is_stamped_);
 
-		if (is_stamped)
-			publisher_stamp = this->create_publisher<geometry_msgs::msg::PoseStamped>("robot_pose", 1);
-		else
-			publisher_ = this->create_publisher<geometry_msgs::msg::Pose>("robot_pose", 1);
-		timer_ = this->create_wall_timer(
-			50ms, std::bind(&RobotPosePublisher::timer_callback, this));
-	}
+    if (is_stamped_) {
+      publisher_stamp_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("robot_pose", 1);
+    } else {
+      publisher_ = this->create_publisher<geometry_msgs::msg::Pose>("robot_pose", 1);
+    }
+    timer_ = this->create_wall_timer(50ms, [this] { timerCallback(); });
+  }
 
 private:
-	void timer_callback()
-	{
-		geometry_msgs::msg::TransformStamped transformStamped;
-		try
-		{
-			transformStamped = tf_buffer_->lookupTransform(map_frame, base_frame,
-														   this->now());
-		}
-		catch (tf2::TransformException &ex)
-		{
-			return;
-		}
-		geometry_msgs::msg::PoseStamped pose_stamped;
-		pose_stamped.header.frame_id = map_frame;
-		pose_stamped.header.stamp = this->now();
+  void timerCallback()
+  {
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    try {
+      transform_stamped = tf_buffer_->lookupTransform(map_frame_, base_frame_, this->now());
+    } catch (tf2::TransformException & ex) {
+      return;
+    }
+    geometry_msgs::msg::PoseStamped pose_stamped;
+    pose_stamped.header.frame_id = map_frame_;
+    pose_stamped.header.stamp = this->now();
 
-		pose_stamped.pose.orientation.x = transformStamped.transform.rotation.x;
-		pose_stamped.pose.orientation.y = transformStamped.transform.rotation.y;
-		pose_stamped.pose.orientation.z = transformStamped.transform.rotation.z;
-		pose_stamped.pose.orientation.w = transformStamped.transform.rotation.w;
+    pose_stamped.pose.orientation.x = transform_stamped.transform.rotation.x;
+    pose_stamped.pose.orientation.y = transform_stamped.transform.rotation.y;
+    pose_stamped.pose.orientation.z = transform_stamped.transform.rotation.z;
+    pose_stamped.pose.orientation.w = transform_stamped.transform.rotation.w;
 
-		pose_stamped.pose.position.x = transformStamped.transform.translation.x;
-		pose_stamped.pose.position.y = transformStamped.transform.translation.y;
-		pose_stamped.pose.position.z = transformStamped.transform.translation.z;
+    pose_stamped.pose.position.x = transform_stamped.transform.translation.x;
+    pose_stamped.pose.position.y = transform_stamped.transform.translation.y;
+    pose_stamped.pose.position.z = transform_stamped.transform.translation.z;
 
-		if (is_stamped)
-			publisher_stamp->publish(pose_stamped);
-		else
-			publisher_->publish(pose_stamped.pose);
-	}
-	rclcpp::TimerBase::SharedPtr timer_;
-	rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr publisher_stamp;
-	rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr publisher_;
-	size_t count_;
-	bool is_stamped = false;
-	std::string base_frame = "base_link";
-	std::string map_frame = "map";
-	std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-	std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+    if (is_stamped_) {
+      publisher_stamp_->publish(pose_stamped);
+    } else {
+      publisher_->publish(pose_stamped.pose);
+    }
+  }
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr publisher_stamp_;
+  rclcpp::Publisher<geometry_msgs::msg::Pose>::SharedPtr publisher_;
+  bool is_stamped_ = false;
+  std::string base_frame_ = "base_link";
+  std::string map_frame_ = "map";
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 };
 
-int main(int argc, char *argv[])
+auto main(int argc, char * argv[]) -> int
 {
-	rclcpp::init(argc, argv);
-	rclcpp::spin(std::make_shared<RobotPosePublisher>());
-	rclcpp::shutdown();
-	return 0;
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<RobotPosePublisher>());
+  rclcpp::shutdown();
+  return 0;
 }

--- a/src/robot_pose_publisher.cpp
+++ b/src/robot_pose_publisher.cpp
@@ -57,7 +57,7 @@ private:
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped =
-        tf_buffer_->lookupTransform(map_frame_, base_frame_, this->now(), rclcpp::Duration::from_seconds(1));
+        tf_buffer_->lookupTransform(map_frame_, base_frame_, rclcpp::Time(0), rclcpp::Duration::from_seconds(1));
     } catch (tf2::TransformException & ex) {
       return;
     }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

lookupTransformを実施する際に、timeoutが未指定でDefaultの0sが入ってしまっていたため,apriltagのような周期的に出力されるFrameとMapフレーム間でのLookupが失敗してしがちなため、`Timeout=1s`を追加。

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->


<!-- 変更の詳細 -->
## Detail
- その他Lintの対応のためFormat変更。
- Timerの周期を変更できるようにパラメータ化

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
